### PR TITLE
An alternate way to construct & authenticate a RobaseService

### DIFF
--- a/src/RobaseService/Robase.lua
+++ b/src/RobaseService/Robase.lua
@@ -32,6 +32,7 @@ local function deepcopy(orig)
 end
 
 local function appendUrlQuery(url, queryName, queryData)
+    if typeof(queryData) == "string" then queryData = ('"%s"'):format(queryData) end
     if url:find("?") then
         return ("%s&%s=%s"):format(url, queryName, queryData)
     else

--- a/src/RobaseService/init.lua
+++ b/src/RobaseService/init.lua
@@ -1,11 +1,7 @@
 local Robase = require(script.Robase)
 local HttpService = game:GetService("HttpService")
 
-local RobaseService = {
-    AuthType = {
-        Legacy = "Legacy";
-    }
-}
+local RobaseService = { }
 RobaseService.BaseUrl = nil
 RobaseService.AuthKey = nil
 RobaseService.__index = RobaseService
@@ -18,31 +14,22 @@ local function fixTrailingSlashes(url)
     return url
 end
 
-function RobaseService.new(baseUrl)
+function RobaseService.new(baseUrl, token)
     if baseUrl == nil then
         error("Bad Argument 1 baseUrl expected, got nil")
+    elseif token==nil then
+        error("Bad Argument 2 token expected, got nil")
     end
 
     local self = setmetatable({}, RobaseService)
     self.BaseUrl = fixTrailingSlashes(baseUrl)
+    self.AuthKey = ".json?auth="..token
     return self
-end
-
-function RobaseService:Authenticate(authType, token)
-    if token == nil then
-        error("Bad Argument 2 token expected, got nil")
-    end
-    
-    if authType == self.AuthType.Legacy then
-        self.AuthKey = ".json?auth="..token
-    else
-        error(('Authenticate method "%s" is not supported'):format(authType))
-    end
 end
 
 function RobaseService:GetRobase(name, scope)
     if self.AuthKey==nil or self.AuthKey=="" then
-        error("You must authenticate RobaseService with an AuthKey to use the RobaseService API")
+        error("You must instantiate RobaseService with an AuthKey to use the RobaseService API")
     elseif self.BaseUrl==nil or self.BaseUrl=="" then
         error("You must instantiate RobaseService with a BaseUrl to use the RobaseService API")
     end

--- a/src/RobaseService/init.lua
+++ b/src/RobaseService/init.lua
@@ -4,7 +4,6 @@ local HttpService = game:GetService("HttpService")
 local RobaseService = {
     AuthType = {
         Legacy = "Legacy";
-        AccessToken = "AccessToken";
     }
 }
 RobaseService.BaseUrl = nil
@@ -36,8 +35,6 @@ function RobaseService:Authenticate(authType, token)
     
     if authType == self.AuthType.Legacy then
         self.AuthKey = ".json?auth="..token
-    elseif authType == self.AuthType.AccessToken then
-        self.AuthKey = ".json?access_token="..token
     else
         error(('Authenticate method "%s" is not supported'):format(authType))
     end

--- a/src/RobaseService/init.lua
+++ b/src/RobaseService/init.lua
@@ -1,7 +1,11 @@
 local Robase = require(script.Robase)
 local HttpService = game:GetService("HttpService")
 
-local RobaseService = { }
+local RobaseService = {
+    AuthType = {
+        Legacy = "Legacy";
+    }
+}
 RobaseService.BaseUrl = nil
 RobaseService.AuthKey = nil
 RobaseService.__index = RobaseService
@@ -14,22 +18,31 @@ local function fixTrailingSlashes(url)
     return url
 end
 
-function RobaseService.new(baseUrl, token)
+function RobaseService.new(baseUrl)
     if baseUrl == nil then
         error("Bad Argument 1 baseUrl expected, got nil")
-    elseif token==nil then
-        error("Bad Argument 2 token expected, got nil")
     end
 
     local self = setmetatable({}, RobaseService)
     self.BaseUrl = fixTrailingSlashes(baseUrl)
-    self.AuthKey = ".json?auth="..token
     return self
+end
+
+function RobaseService:Authenticate(authType, token)
+    if token == nil then
+        error("Bad Argument 2 token expected, got nil")
+    end
+    
+    if authType == self.AuthType.Legacy then
+        self.AuthKey = ".json?auth="..token
+    else
+        error(('Authenticate method "%s" is not supported'):format(authType))
+    end
 end
 
 function RobaseService:GetRobase(name, scope)
     if self.AuthKey==nil or self.AuthKey=="" then
-        error("You must instantiate RobaseService with an AuthKey to use the RobaseService API")
+        error("You must authenticate RobaseService with an AuthKey to use the RobaseService API")
     elseif self.BaseUrl==nil or self.BaseUrl=="" then
         error("You must instantiate RobaseService with a BaseUrl to use the RobaseService API")
     end

--- a/src/RobaseService/init.lua
+++ b/src/RobaseService/init.lua
@@ -4,6 +4,7 @@ local HttpService = game:GetService("HttpService")
 local RobaseService = {
     AuthType = {
         Legacy = "Legacy";
+        AccessToken = "AccessToken";
     }
 }
 RobaseService.BaseUrl = nil
@@ -35,6 +36,8 @@ function RobaseService:Authenticate(authType, token)
     
     if authType == self.AuthType.Legacy then
         self.AuthKey = ".json?auth="..token
+    elseif authType == self.AuthType.AccessToken then
+        self.AuthKey = ".json?access_token="..token
     else
         error(('Authenticate method "%s" is not supported'):format(authType))
     end


### PR DESCRIPTION
### An Implementation of #7 
Example Code: 
```lua
local Database = RobaseService.new(baseUrl: string)
Database:Authenticate(RobaseService.AuthType.Legacy, token: string)
```

There are currently two AuthType implemented:
1. `RobaseService.AuthType.Legacy`
2. `RobaseService.AuthType.AccessToken`